### PR TITLE
Add ClientException.toNSError() function.

### DIFF
--- a/lib/src/commonMain/kotlin/io.telereso.kmp.core/Http.kt
+++ b/lib/src/commonMain/kotlin/io.telereso.kmp.core/Http.kt
@@ -189,6 +189,7 @@ object Http {
                 httpStatusCode = this.response.status.value, // setting the http status code
                 errorBody = errorBody, // setting the error body
                 message = errorMessage, // setting the error message
+                code = errorBody.code, // setting the error code
                 errorType = "HTTP", // setting the error type
                 cause = cause?:this, // setting the cause of the error
                 errorString = body, // setting the error string,

--- a/lib/src/commonMain/kotlin/io.telereso.kmp.core/extensions /Boolean.kt
+++ b/lib/src/commonMain/kotlin/io.telereso.kmp.core/extensions /Boolean.kt
@@ -1,0 +1,36 @@
+/*
+ * MIT License
+ *
+ * Copyright (c) 2023 Telereso
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in all
+ * copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+ * SOFTWARE.
+ */
+
+
+private fun Boolean?.isTrue():Boolean{
+    return this == true
+}
+
+private fun Boolean?.isFalse():Boolean{
+    return this == false
+}
+
+private fun Boolean?.isNull():Boolean{
+    return this == null
+}

--- a/lib/src/commonMain/kotlin/io.telereso.kmp.core/models/ClientException.kt
+++ b/lib/src/commonMain/kotlin/io.telereso.kmp.core/models/ClientException.kt
@@ -53,6 +53,7 @@ open class ClientException(
     val errorString: String? = null,
     val errorType: String? = null,
     val httpURl: String? = null,
+    val code: String? = null
 ) : Throwable() {
     @JsName("ClientExceptionConstructor")
     constructor(cause: Throwable? = null) : this(null, cause = cause)

--- a/lib/src/iosMain/kotlin/PlatformIos.kt
+++ b/lib/src/iosMain/kotlin/PlatformIos.kt
@@ -159,5 +159,5 @@ fun ClientException.toNSError(): NSError {
     val userInfoMap: Map<Any?, *> = userInfo.toMap()
 
     // Create and return the NSError object with the appropriate information.
-    return NSError(domain = httpURl, code = (httpStatusCode ?: 0).convert(), userInfo = userInfoMap)
+    return NSError(domain = ClientException::class.simpleName, code = (httpStatusCode ?: 0).convert(), userInfo = userInfoMap)
 }

--- a/lib/src/iosMain/kotlin/PlatformIos.kt
+++ b/lib/src/iosMain/kotlin/PlatformIos.kt
@@ -159,5 +159,5 @@ fun ClientException.toNSError(): NSError {
     val userInfoMap: Map<Any?, *> = userInfo.toMap()
 
     // Create and return the NSError object with the appropriate information.
-    return NSError(domain = ClientException::class.simpleName, code = (httpStatusCode ?: 0).convert(), userInfo = userInfoMap)
+    return NSError(domain = this::class.simpleName, code = (httpStatusCode ?: 0).convert(), userInfo = userInfoMap)
 }


### PR DESCRIPTION
Add ClientException.toNSError() function to improve NSError interop in iOS projects using Kotlin Multiplatform. 

The function converts a ClientException instance to an NSError instance with custom error information, including the failing URL, HTTP status code, error body, error type, and error string.